### PR TITLE
Fix for Python 3.6 (openSUSE Leap 15.4) by removing dirs_exist_ok

### DIFF
--- a/cargo_audit
+++ b/cargo_audit
@@ -145,7 +145,7 @@ def do_cargo_audit(workdir, lsrcdir, lockfile):
             (_, dirname) = os.path.split(lsrcdir)
             dirpath = os.path.join(tmpdirname, dirname)
             log.debug(f" copying sources into {dirpath}")
-            lsrcdir = shutil.copytree(lsrcdir, dirpath, dirs_exist_ok=True)
+            lsrcdir = shutil.copytree(lsrcdir, dirpath)
 
         log.debug(f"srcdirs {srcdirs}")
 


### PR DESCRIPTION
https://docs.python.org/3/library/shutil.html says that `dirs_exist_ok` works since Python 3.8

AFAIK the directory will not exist since its parent is a new tmpdir.

Even re-running the command works. But I did not do other testing.